### PR TITLE
Automatic addition of new playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ After installing the plugin, visit its configuration page and add your Spotify C
 
 When the authorisation is done, you can continue with the plugin configuration page.
 
-Go to the section `Playlist Configuration` and click on `Add new playlist`. This creates a new row with three fields:
+Go to the section `Playlist Configuration` and click on `Add new playlist`. This creates a new row with four fields:
 - `Spotify ID`: Paste the identifier of the Spotify playlists that you want to import in here.
 - `Target Name`: Jellyfin playlist name. Keep this empty if the original name from Spotify should be used.
 - `Target User`: If you want to set another user as the playlist owner, select them here.
+- `ID Type`: For playlists, leave this as `Playlist`. For more info, see [Auto-Adding playlists](#auto-adding-playlists)
 
 Following "Spotify ID" formats work:
 - The raw ID, e.g. `4cOdK2wGLETKBW3PvgPWqT`
@@ -82,6 +83,14 @@ If you experience issues with tracks not matching even if they exist, you can "r
 
 1. `Match Type` determines how strict the individual comparison is (e.g. if case differences are ignored)
 2. `Enable * comparison` fully enables or disables the comparison of the respective condition
+
+### Auto-Adding playlists
+
+If you just want to import all playlists of a Spotify user, you do not need to specify every single playlist ID as a new entry.
+
+Instead, grab the ID of the Spotify user (e.g. from the link to their profile) and paste it into the `Spotify ID` field. To tell the plugin that this should be recognised as a user ID, set the `ID Type` to `User`.
+
+Afterwards, following runs of the import task will include all playlists of this user and map them to the configured Jellyfin user.
 
 ## To do
 

--- a/Viperinius.Plugin.SpotifyImport.Tests/PlaylistSyncTests.cs
+++ b/Viperinius.Plugin.SpotifyImport.Tests/PlaylistSyncTests.cs
@@ -18,8 +18,9 @@ namespace Viperinius.Plugin.SpotifyImport.Tests
             MediaBrowser.Controller.Playlists.IPlaylistManager playlistManager,
             MediaBrowser.Controller.Library.ILibraryManager libraryManager,
             MediaBrowser.Controller.Library.IUserManager userManager,
-            List<ProviderPlaylistInfo> playlists)
-            : base(logger, playlistManager, libraryManager, userManager, playlists)
+            List<ProviderPlaylistInfo> playlists,
+            Dictionary<string, string> userPlaylistIds)
+            : base(logger, playlistManager, libraryManager, userManager, playlists, userPlaylistIds)
         {
         }
 

--- a/Viperinius.Plugin.SpotifyImport/Configuration/TargetPlaylistConfiguration.cs
+++ b/Viperinius.Plugin.SpotifyImport/Configuration/TargetPlaylistConfiguration.cs
@@ -7,6 +7,22 @@ using System.Threading.Tasks;
 namespace Viperinius.Plugin.SpotifyImport.Configuration
 {
     /// <summary>
+    /// Type the configuration describes.
+    /// </summary>
+    public enum TargetConfigurationType
+    {
+        /// <summary>
+        /// Configuration contains a playlist id.
+        /// </summary>
+        Playlist,
+
+        /// <summary>
+        /// Configuration contains a user id.
+        /// </summary>
+        User,
+    }
+
+    /// <summary>
     /// Holds the information about a configured playlist.
     /// </summary>
     public class TargetPlaylistConfiguration
@@ -35,5 +51,10 @@ namespace Viperinius.Plugin.SpotifyImport.Configuration
         /// Gets or sets the targeted Jellyfin user name.
         /// </summary>
         public string UserName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the configured id.
+        /// </summary>
+        public TargetConfigurationType Type { get; set; }
     }
 }

--- a/Viperinius.Plugin.SpotifyImport/Configuration/configPage.html
+++ b/Viperinius.Plugin.SpotifyImport/Configuration/configPage.html
@@ -56,6 +56,8 @@
                                 <li>URL (ex.: https://open.spotify.com/playlist/4cOdK2wGLETKBW3PvgPWqT)</li>
                             </ul>
                             If you want to keep the Spotify playlist name, leave the Target Name field empty.
+                            <br>
+                            Instead of a single playlist ID, you can also use a user ID to include all of their playlists automatically. This requires the "ID Type" to be set to "User".
                         </span>
                         <div class="innerPlaylistContainer">
                             <table id="playlistTable" class="stripedTable ui-responsive table-stroke detailTable" data-role="table">
@@ -63,6 +65,7 @@
                                     <th class="detailTableHeaderCell" data-priority="persist">Spotify ID</th>
                                     <th class="detailTableHeaderCell" data-priority="persist">Target Name</th>
                                     <th class="detailTableHeaderCell" data-priority="persist">Target User</th>
+                                    <th class="detailTableHeaderCell" data-priority="persist">ID Type</th>
                                     <th></th>
                                 </thead>
                                 <tbody>

--- a/Viperinius.Plugin.SpotifyImport/GenericPlaylistProvider.cs
+++ b/Viperinius.Plugin.SpotifyImport/GenericPlaylistProvider.cs
@@ -40,6 +40,12 @@ namespace Viperinius.Plugin.SpotifyImport
 
         public abstract void SetUpProvider();
 
+        public virtual async Task<List<string>?> GetUserPlaylistIds(string userId, CancellationToken? cancellationToken = null)
+        {
+            var playlistsInfo = await GetUserPlaylistsInfo(userId, cancellationToken).ConfigureAwait(false);
+            return playlistsInfo?.Select(p => p.Id).ToList();
+        }
+
         public virtual async Task PopulatePlaylists(List<string> playlistIds, CancellationToken? cancellationToken = null)
         {
             _logger.LogInformation("Starting to query {Amount} playlists from {Name}", playlistIds.Count, Name);
@@ -57,6 +63,8 @@ namespace Viperinius.Plugin.SpotifyImport
                 }
             }
         }
+
+        protected abstract Task<List<ProviderPlaylistInfo>?> GetUserPlaylistsInfo(string userId, CancellationToken? cancellationToken = null);
 
         protected abstract Task<ProviderPlaylistInfo?> GetPlaylist(string playlistId, CancellationToken? cancellationToken = null);
 

--- a/Viperinius.Plugin.SpotifyImport/PlaylistSync.cs
+++ b/Viperinius.Plugin.SpotifyImport/PlaylistSync.cs
@@ -21,19 +21,22 @@ namespace Viperinius.Plugin.SpotifyImport
         private readonly ILibraryManager _libraryManager;
         private readonly IUserManager _userManager;
         private readonly List<ProviderPlaylistInfo> _providerPlaylists;
+        private readonly Dictionary<string, string> _userPlaylistIds;
 
         public PlaylistSync(
             ILogger<PlaylistSync> logger,
             IPlaylistManager playlistManager,
             ILibraryManager libraryManager,
             IUserManager userManager,
-            List<ProviderPlaylistInfo> playlists)
+            List<ProviderPlaylistInfo> playlists,
+            Dictionary<string, string> userPlaylistIds)
         {
             _logger = logger;
             _playlistManager = playlistManager;
             _libraryManager = libraryManager;
             _userManager = userManager;
             _providerPlaylists = playlists;
+            _userPlaylistIds = userPlaylistIds;
         }
 
         public async Task Execute(CancellationToken cancellationToken = default)
@@ -46,8 +49,15 @@ namespace Viperinius.Plugin.SpotifyImport
                 var targetConfig = Plugin.Instance?.Configuration.Playlists.FirstOrDefault(p => p.Id == providerPlaylist.Id);
                 if (targetConfig == null || string.IsNullOrEmpty(targetConfig.Id))
                 {
-                    _logger.LogError("Failed to get target playlist configuration for playlist {Id}", providerPlaylist.Id);
-                    continue;
+                    // is this a playlist specified by user?
+                    var userId = _userPlaylistIds.GetValueOrDefault(providerPlaylist.Id);
+                    targetConfig = Plugin.Instance?.Configuration.Playlists.FirstOrDefault(p => p.Type == Configuration.TargetConfigurationType.User && p.Id == userId);
+
+                    if (targetConfig == null || string.IsNullOrEmpty(targetConfig.Id))
+                    {
+                        _logger.LogError("Failed to get target playlist configuration for playlist {Id}", providerPlaylist.Id);
+                        continue;
+                    }
                 }
 
                 // get the targeted user

--- a/Viperinius.Plugin.SpotifyImport/PlaylistSync.cs
+++ b/Viperinius.Plugin.SpotifyImport/PlaylistSync.cs
@@ -58,6 +58,9 @@ namespace Viperinius.Plugin.SpotifyImport
                         _logger.LogError("Failed to get target playlist configuration for playlist {Id}", providerPlaylist.Id);
                         continue;
                     }
+
+                    // custom name not supported in this case
+                    targetConfig.Name = string.Empty;
                 }
 
                 // get the targeted user


### PR DESCRIPTION
Adds support along the lines of #6.

You can enter a Spotify user ID instead of a playlist ID and the plugin will add all (visible) playlists of this user.
If the user is your own / the one used to authenticate, this includes private playlists.

It is currently limited to playlists the specified user actually owns, so followed or collaborative playlists from other users are not auto-added.