### PR TITLE
Add migration helper

### DIFF
--- a/Viperinius.Plugin.SpotifyImport/Configuration/PluginConfiguration.cs
+++ b/Viperinius.Plugin.SpotifyImport/Configuration/PluginConfiguration.cs
@@ -18,6 +18,7 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     public PluginConfiguration()
     {
+        Version = string.Empty;
         SpotifyClientId = string.Empty;
         PlaylistIds = Array.Empty<string>();
         Playlists = Array.Empty<TargetPlaylistConfiguration>();
@@ -26,6 +27,11 @@ public class PluginConfiguration : BasePluginConfiguration
         ItemMatchLevel = ItemMatchLevel.Default;
         MissingTrackListsDateFormat = "yyyy-MM-dd_HH-mm";
     }
+
+    /// <summary>
+    /// Gets or sets the config version.
+    /// </summary>
+    public string Version { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to enable verbose logging (ex: spotify requests).

--- a/Viperinius.Plugin.SpotifyImport/Configuration/PluginConfiguration.cs
+++ b/Viperinius.Plugin.SpotifyImport/Configuration/PluginConfiguration.cs
@@ -20,7 +20,6 @@ public class PluginConfiguration : BasePluginConfiguration
     {
         Version = string.Empty;
         SpotifyClientId = string.Empty;
-        PlaylistIds = Array.Empty<string>();
         Playlists = Array.Empty<TargetPlaylistConfiguration>();
         Users = Array.Empty<TargetUserConfiguration>();
         ItemMatchCriteriaRaw = (int)(ItemMatchCriteria.TrackName | ItemMatchCriteria.AlbumName | ItemMatchCriteria.AlbumArtists | ItemMatchCriteria.Artists);
@@ -42,12 +41,6 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the Spotify client ID.
     /// </summary>
     public string SpotifyClientId { get; set; }
-
-    /// <summary>
-    /// Gets or sets the targeted playlist IDs.
-    /// Only used for compatibility purposes for old versions.
-    /// </summary>
-    public string[] PlaylistIds { get; set; }
 
     /// <summary>
     /// Gets or sets the targeted playlists.

--- a/Viperinius.Plugin.SpotifyImport/Exceptions/MigrationException.cs
+++ b/Viperinius.Plugin.SpotifyImport/Exceptions/MigrationException.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Viperinius.Plugin.SpotifyImport.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when a migration failed.
+    /// </summary>
+    [Serializable]
+    public class MigrationException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MigrationException"/> class.
+        /// </summary>
+        public MigrationException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MigrationException"/> class.
+        /// </summary>
+        /// <param name="message">Message.</param>
+        public MigrationException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MigrationException"/> class.
+        /// </summary>
+        /// <param name="message">Message.</param>
+        /// <param name="innerException">Inner Exception.</param>
+        public MigrationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MigrationException"/> class.
+        /// </summary>
+        /// <param name="serializationInfo">Info.</param>
+        /// <param name="streamingContext">Context.</param>
+        protected MigrationException(
+            System.Runtime.Serialization.SerializationInfo serializationInfo,
+            System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext)
+        {
+        }
+    }
+}

--- a/Viperinius.Plugin.SpotifyImport/Exceptions/TaskAbortedException.cs
+++ b/Viperinius.Plugin.SpotifyImport/Exceptions/TaskAbortedException.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Viperinius.Plugin.SpotifyImport.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when a task failed.
+    /// </summary>
+    [Serializable]
+    public class TaskAbortedException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskAbortedException"/> class.
+        /// </summary>
+        public TaskAbortedException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskAbortedException"/> class.
+        /// </summary>
+        /// <param name="message">Message.</param>
+        public TaskAbortedException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskAbortedException"/> class.
+        /// </summary>
+        /// <param name="message">Message.</param>
+        /// <param name="innerException">Inner Exception.</param>
+        public TaskAbortedException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskAbortedException"/> class.
+        /// </summary>
+        /// <param name="serializationInfo">Info.</param>
+        /// <param name="streamingContext">Context.</param>
+        protected TaskAbortedException(
+            System.Runtime.Serialization.SerializationInfo serializationInfo,
+            System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext)
+        {
+        }
+    }
+}

--- a/Viperinius.Plugin.SpotifyImport/Migrations/BaseMigration.cs
+++ b/Viperinius.Plugin.SpotifyImport/Migrations/BaseMigration.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Logging;
+using Viperinius.Plugin.SpotifyImport.Exceptions;
+
+namespace Viperinius.Plugin.SpotifyImport.Migrations
+{
+    /// <summary>
+    /// Migration base class.
+    /// </summary>
+    public abstract class BaseMigration
+    {
+        private readonly string _configPath;
+        private readonly IXmlSerializer _xmlSerialiser;
+        private readonly ILogger _logger;
+
+        internal BaseMigration(string configPath, IXmlSerializer serialiser, ILogger logger)
+        {
+            _configPath = configPath;
+            _xmlSerialiser = serialiser;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Gets the last release version that supports the config to be migrated.
+        /// </summary>
+        public abstract Version LatestWorkingRelease { get; }
+
+        /// <summary>
+        /// Gets the path to the config file.
+        /// </summary>
+        protected string ConfigPath => _configPath;
+
+        /// <summary>
+        /// Gets the xml serialiser.
+        /// </summary>
+        protected IXmlSerializer XmlSerialiser => _xmlSerialiser;
+
+        /// <summary>
+        /// Gets the logger.
+        /// </summary>
+        protected ILogger Logger => _logger;
+
+        /// <summary>
+        /// Run the migration.
+        /// </summary>
+        /// <param name="currentConfigVersion">The version of the config file.</param>
+        /// <returns>True if successful / nothing to be done, false otherwise.</returns>
+        public abstract bool Execute(Version currentConfigVersion);
+
+        /// <summary>
+        /// Parse the config file into a configuration fit for <see cref="LatestWorkingRelease"/>.
+        /// </summary>
+        /// <typeparam name="TConfiguration">The old configuration representation.</typeparam>
+        /// <returns>The parsed configuration.</returns>
+        protected TConfiguration ParseConfigFile<TConfiguration>()
+            where TConfiguration : BasePluginConfiguration
+        {
+            try
+            {
+                return (TConfiguration)XmlSerialiser.DeserializeFromFile(typeof(TConfiguration), ConfigPath);
+            }
+            catch (Exception e)
+            {
+                throw new MigrationException("Failed to parse config file", e);
+            }
+        }
+    }
+}

--- a/Viperinius.Plugin.SpotifyImport/Migrations/PlaylistIdMigration.cs
+++ b/Viperinius.Plugin.SpotifyImport/Migrations/PlaylistIdMigration.cs
@@ -1,0 +1,94 @@
+#pragma warning disable CA1034
+#pragma warning disable CA1819
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Logging;
+using Viperinius.Plugin.SpotifyImport.Configuration;
+using Viperinius.Plugin.SpotifyImport.Exceptions;
+
+namespace Viperinius.Plugin.SpotifyImport.Migrations
+{
+    /// <summary>
+    /// Reference: 2023-05-14 [Commit: 0f7374b608f0e2a6287250ffa12731020fb4e40d]
+    /// Convert any existing legacy playlist IDs to full playlist configurations.
+    /// </summary>
+    public class PlaylistIdMigration : BaseMigration
+    {
+        internal PlaylistIdMigration(
+            string configPath,
+            IXmlSerializer serialiser,
+            ILogger logger) : base(configPath, serialiser, logger)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override Version LatestWorkingRelease { get; } = new Version(1, 1, 1, 0);
+
+        /// <inheritdoc/>
+        public override bool Execute(Version currentConfigVersion)
+        {
+            if (currentConfigVersion > LatestWorkingRelease)
+            {
+                return true;
+            }
+
+            try
+            {
+                var config = ParseConfigFile<PluginConfiguration>();
+
+                if (!config.PlaylistIds.Any())
+                {
+                    return true;
+                }
+
+                var legacyPlaylistCount = config.PlaylistIds.Length;
+
+                var playlists = Plugin.Instance!.Configuration.Playlists.ToList();
+                foreach (var playlistId in config.PlaylistIds.Where(id => !playlists.Where(p => p.Id == id).Any()))
+                {
+                    playlists.Add(new TargetPlaylistConfiguration
+                    {
+                        Id = playlistId
+                    });
+                }
+
+                Plugin.Instance.Configuration.Playlists = playlists.ToArray();
+                Logger.LogInformation("Migrated {Count} legacy playlist configurations", legacyPlaylistCount);
+
+                return true;
+            }
+            catch (MigrationException e)
+            {
+                Logger.LogError(e, "Failed");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Parts of the configuration needed to migrate.
+        /// </summary>
+        public class PluginConfiguration : BasePluginConfiguration
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="PluginConfiguration"/> class.
+            /// </summary>
+            public PluginConfiguration()
+            {
+                PlaylistIds = Array.Empty<string>();
+            }
+
+            /// <summary>
+            /// Gets or sets the targeted playlist IDs.
+            /// Only used for compatibility purposes for old versions.
+            /// </summary>
+            public string[] PlaylistIds { get; set; }
+        }
+    }
+}

--- a/Viperinius.Plugin.SpotifyImport/Migrations/UserPlaylistsMigration.cs
+++ b/Viperinius.Plugin.SpotifyImport/Migrations/UserPlaylistsMigration.cs
@@ -1,0 +1,154 @@
+#pragma warning disable CA1034
+#pragma warning disable CA1819
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Logging;
+using Viperinius.Plugin.SpotifyImport.Exceptions;
+
+namespace Viperinius.Plugin.SpotifyImport.Migrations
+{
+    /// <summary>
+    /// Reference: 2023-08-30 [Commit: 0018bbc8ba0a463e56100e3236ee94e8147be5f2]
+    /// Convert any existing target playlist configurations containing a user ID to target user configurations.
+    /// </summary>
+    public class UserPlaylistsMigration : BaseMigration
+    {
+        internal UserPlaylistsMigration(
+            string configPath,
+            IXmlSerializer serialiser,
+            ILogger logger) : base(configPath, serialiser, logger)
+        {
+        }
+
+        /// <summary>
+        /// Type the configuration describes.
+        /// </summary>
+        public enum TargetConfigurationType
+        {
+            /// <summary>
+            /// Configuration contains a playlist id.
+            /// </summary>
+            Playlist,
+
+            /// <summary>
+            /// Configuration contains a user id.
+            /// </summary>
+            User,
+        }
+
+        /// <inheritdoc/>
+        public override Version LatestWorkingRelease { get; } = new Version(1, 3, 0, 0);
+
+        /// <inheritdoc/>
+        public override bool Execute(Version currentConfigVersion)
+        {
+            if (currentConfigVersion > LatestWorkingRelease)
+            {
+                return true;
+            }
+
+            try
+            {
+                var config = ParseConfigFile<PluginConfiguration>();
+
+                if (!config.Playlists.Any())
+                {
+                    return true;
+                }
+
+                var users = Plugin.Instance!.Configuration.Users.ToList();
+                var playlists = Plugin.Instance.Configuration.Playlists.ToList();
+                var migratedCount = 0;
+                foreach (var playlist in config.Playlists.Where(p => p.Type == TargetConfigurationType.User))
+                {
+                    var user = new Configuration.TargetUserConfiguration
+                    {
+                        Id = playlist.Id,
+                        UserName = playlist.UserName,
+                        OnlyOwnPlaylists = true // this was always done in this version, so keep the behaviour
+                    };
+
+                    if (!users.Any(u => u.Id == user.Id))
+                    {
+                        users.Add(user);
+                    }
+
+                    playlists.RemoveAll(p => p.Id == playlist.Id);
+                    migratedCount++;
+                }
+
+                Plugin.Instance.Configuration.Users = users.ToArray();
+                Plugin.Instance.Configuration.Playlists = playlists.ToArray();
+                Logger.LogInformation("Migrated {Count} target playlist configurations with user IDs", migratedCount);
+
+                return true;
+            }
+            catch (MigrationException e)
+            {
+                Logger.LogError(e, "Failed");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Parts of the configuration needed to migrate.
+        /// </summary>
+        public class PluginConfiguration : BasePluginConfiguration
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="PluginConfiguration"/> class.
+            /// </summary>
+            public PluginConfiguration()
+            {
+                Playlists = Array.Empty<TargetPlaylistConfiguration>();
+            }
+
+            /// <summary>
+            /// Gets or sets the targeted playlists.
+            /// </summary>
+            public TargetPlaylistConfiguration[] Playlists { get; set; }
+        }
+
+        /// <summary>
+        /// Holds the information about a configured playlist.
+        /// </summary>
+        public class TargetPlaylistConfiguration
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TargetPlaylistConfiguration"/> class.
+            /// </summary>
+            public TargetPlaylistConfiguration()
+            {
+                Id = string.Empty;
+                Name = string.Empty;
+                UserName = string.Empty;
+            }
+
+            /// <summary>
+            /// Gets or sets the playlist ID.
+            /// </summary>
+            public string Id { get; set; }
+
+            /// <summary>
+            /// Gets or sets the targeted Jellyfin playlist name.
+            /// </summary>
+            public string Name { get; set; }
+
+            /// <summary>
+            /// Gets or sets the targeted Jellyfin user name.
+            /// </summary>
+            public string UserName { get; set; }
+
+            /// <summary>
+            /// Gets or sets the type of the configured id.
+            /// </summary>
+            public TargetConfigurationType Type { get; set; }
+        }
+    }
+}

--- a/Viperinius.Plugin.SpotifyImport/Plugin.cs
+++ b/Viperinius.Plugin.SpotifyImport/Plugin.cs
@@ -65,6 +65,15 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     }
 
     /// <summary>
+    /// Get the xml serialiser.
+    /// </summary>
+    /// <returns>Xml Serialiser.</returns>
+    public IXmlSerializer GetInternalXmlSerializer()
+    {
+        return XmlSerializer;
+    }
+
+    /// <summary>
     /// Sets the plugin instance.
     /// </summary>
     /// <param name="instance">New Instance.</param>

--- a/Viperinius.Plugin.SpotifyImport/Plugin.cs
+++ b/Viperinius.Plugin.SpotifyImport/Plugin.cs
@@ -32,6 +32,11 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public override Guid Id => Guid.Parse("F03D0ADB-289F-4986-BD6F-2468025249B3");
 
     /// <summary>
+    /// Gets or sets a value indicating whether the plugin instance was fully initialised during server start.
+    /// </summary>
+    public bool IsInitialised { get; set; }
+
+    /// <summary>
     /// Gets the base path for the plugin API.
     /// </summary>
     public static string PluginApiBase => $"{nameof(Viperinius)}.{nameof(Viperinius.Plugin)}.{nameof(SpotifyImport)}";

--- a/Viperinius.Plugin.SpotifyImport/ServerEntrypoint.cs
+++ b/Viperinius.Plugin.SpotifyImport/ServerEntrypoint.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Controller.Plugins;
+using Microsoft.Extensions.Logging;
+
+namespace Viperinius.Plugin.SpotifyImport
+{
+    /// <summary>
+    /// Entrypoint called when starting the server.
+    /// </summary>
+    public class ServerEntrypoint : IServerEntryPoint
+    {
+        private readonly ILogger<ServerEntrypoint> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServerEntrypoint"/> class.
+        /// </summary>
+        /// <param name="logger">Logger.</param>
+        public ServerEntrypoint(ILogger<ServerEntrypoint> logger)
+        {
+            _logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public Task RunAsync()
+        {
+            _logger.LogInformation("Entrypoint");
+
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Internal Dispose.
+        /// </summary>
+        /// <param name="dispose">Should dispose.</param>
+        protected virtual void Dispose(bool dispose)
+        {
+        }
+    }
+}


### PR DESCRIPTION
In case any breaking changes are made regarding the plugin configuration, config files from older versions need to be migrated to the new format.

This is especially needed after the changes from #8 would break any configs containing the previous format of specifying Spotify user IDs.