### PR TITLE
Reintroduce legacy matching

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.7.0.2</Version>
-        <AssemblyVersion>1.7.0.2</AssemblyVersion>
-        <FileVersion>1.7.0.2</FileVersion>
+        <Version>1.7.0.3</Version>
+        <AssemblyVersion>1.7.0.3</AssemblyVersion>
+        <FileVersion>1.7.0.3</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.7.0.1</Version>
-        <AssemblyVersion>1.7.0.1</AssemblyVersion>
-        <FileVersion>1.7.0.1</FileVersion>
+        <Version>1.7.0.2</Version>
+        <AssemblyVersion>1.7.0.2</AssemblyVersion>
+        <FileVersion>1.7.0.2</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.7.0.0</Version>
-        <AssemblyVersion>1.7.0.0</AssemblyVersion>
-        <FileVersion>1.7.0.0</FileVersion>
+        <Version>1.7.0.1</Version>
+        <AssemblyVersion>1.7.0.1</AssemblyVersion>
+        <FileVersion>1.7.0.1</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Viperinius.Plugin.SpotifyImport/Api/DebugController.cs
+++ b/Viperinius.Plugin.SpotifyImport/Api/DebugController.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Mime;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Library;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Viperinius.Plugin.SpotifyImport.Api
+{
+    /// <summary>
+    /// The API controller for missing track lists.
+    /// </summary>
+    [ApiController]
+    [Produces(MediaTypeNames.Application.Json)]
+    [Authorize(Policy = "DefaultAuthorization")]
+    public class DebugController : ControllerBase
+    {
+        private readonly ILibraryManager _libraryManager;
+        private readonly IUserManager _userManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DebugController"/> class.
+        /// </summary>
+        /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+        /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
+        public DebugController(ILibraryManager libraryManager, IUserManager userManager)
+        {
+            _libraryManager = libraryManager;
+            _userManager = userManager;
+        }
+
+        /// <summary>
+        /// Dump music metadata to file.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The file.</returns>
+        [HttpPost($"{nameof(Viperinius)}.{nameof(Viperinius.Plugin)}.{nameof(SpotifyImport)}/Debug/DumpMetadata")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<ActionResult> DumpMetadata(CancellationToken cancellationToken)
+        {
+            var task = new Tasks.DebugDumpMetadataTask(_libraryManager, _userManager);
+            await task.ExecuteAsync(new Progress<double>(), cancellationToken).ConfigureAwait(false);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Dump all references of a music track to file.
+        /// </summary>
+        /// <param name="name">Track name.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The file.</returns>
+        [HttpPost($"{nameof(Viperinius)}.{nameof(Viperinius.Plugin)}.{nameof(SpotifyImport)}/Debug/DumpTrackRefs")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<ActionResult> DumpRefsToFile([FromQuery, Required] string name, CancellationToken cancellationToken)
+        {
+            var queryResult = _libraryManager.GetItemsResult(new InternalItemsQuery
+            {
+                Name = name,
+                MediaTypes = new[] { "Audio" },
+                Recursive = true
+            });
+
+            var alreadyIncludedIds = new List<Guid>();
+
+            foreach (var item in queryResult.Items)
+            {
+                if (alreadyIncludedIds.Contains(item.Id))
+                {
+                    continue;
+                }
+
+                var dumpFilePath = MissingTrackStore.GetFilePath($"DEBUG_REF_{item.Id}");
+
+                if (item is not Audio audio)
+                {
+                    continue;
+                }
+
+                var trackRef = new ItemRef
+                {
+                    Id = audio.Id.ToString(),
+                    Name = audio.Name,
+                    MediaType = audio.MediaType,
+                    ParentId = audio.ParentId.ToString(),
+                    IsTopParent = audio.IsTopParent,
+                    DisplayParentId = audio.DisplayParentId.ToString(),
+                };
+                var trackRefs = new Dictionary<string, ItemRef>
+                {
+                    { "Track", trackRef },
+                };
+
+                // add album entity if set
+                if (audio.AlbumEntity != null)
+                {
+                    var albumEntityRef = new ItemRef
+                    {
+                        Id = audio.AlbumEntity.Id.ToString(),
+                        Name = audio.AlbumEntity.Name,
+                        MediaType = audio.AlbumEntity.MediaType,
+                        ParentId = audio.AlbumEntity.ParentId.ToString(),
+                        IsTopParent = audio.AlbumEntity.IsTopParent,
+                        DisplayParentId = audio.AlbumEntity.DisplayParentId.ToString(),
+                    };
+                    trackRefs.Add("TrackAlbumEntity", albumEntityRef);
+                }
+
+                // get track parents
+                int ii = 1;
+                var nextParent = item;
+                var nextRef = new ItemRef();
+                while (!nextRef.IsTopParent && ii <= 10)
+                {
+                    nextParent = _libraryManager.GetItemById(nextParent.ParentId);
+                    nextRef = new ItemRef
+                    {
+                        Id = nextParent.Id.ToString(),
+                        Name = nextParent.Name,
+                        MediaType = nextParent.MediaType,
+                        ParentId = nextParent.ParentId.ToString(),
+                        IsTopParent = nextParent.IsTopParent,
+                        DisplayParentId = nextParent.DisplayParentId.ToString(),
+                    };
+                    trackRefs.Add($"Parent{ii}", nextRef);
+                    ii++;
+                }
+
+                // reverse search now
+                var artistNames = audio.Artists;
+                var artistRefs = new Dictionary<string, ArtistRef>();
+                foreach (var artistName in artistNames)
+                {
+                    var artistResult = _libraryManager.GetArtists(new InternalItemsQuery
+                    {
+                        SearchTerm = artistName[0..Math.Min(artistName.Length, 5)],
+                    }).Items.Select(i => i.Item);
+                    var resultCount1 = artistResult.Count();
+                    artistResult = artistResult.Concat(_libraryManager.GetItemsResult(new InternalItemsQuery
+                    {
+                        SearchTerm = artistName[0..Math.Min(artistName.Length, 5)],
+                    }).Items);
+                    var resultCount2 = artistResult.Count() - resultCount1;
+
+                    var jj = 1;
+                    foreach (var artistItem in artistResult)
+                    {
+                        if (artistItem is not MusicArtist artist)
+                        {
+                            continue;
+                        }
+
+                        var artistRef = new ArtistRef
+                        {
+                            Id = artist.Id.ToString(),
+                            Name = artist.Name,
+                            MediaType = artist.MediaType,
+                            ParentId = artist.ParentId.ToString(),
+                            IsTopParent = artist.IsTopParent,
+                            DisplayParentId = artist.DisplayParentId.ToString(),
+                            Children = artist.Children.Select(c => new ItemRef
+                            {
+                                Id = c.Id.ToString(),
+                                Name = c.Name,
+                                MediaType = c.MediaType,
+                            }).ToList(),
+                            RecursiveChildren = artist.RecursiveChildren.Select(c => new ItemRef
+                            {
+                                Id = c.Id.ToString(),
+                                Name = c.Name,
+                                MediaType = c.MediaType,
+                            }).ToList(),
+                        };
+                        artistRefs.Add($"Artist{jj}/{resultCount1}/{resultCount2}", artistRef);
+
+                        // album by album artists
+                        var albums = _libraryManager.GetItemList(new InternalItemsQuery
+                        {
+                            AlbumArtistIds = new[] { artist.Id },
+                            IncludeItemTypes = new[] { BaseItemKind.MusicAlbum }
+                        });
+                        for (int kk = 0; kk < albums.Count; kk++)
+                        {
+                            var album = albums[kk];
+                            trackRefs.Add($"AlbumByAlbumArtist{kk}/{jj}/{artistName}", new ItemRef
+                            {
+                                Id = album.Id.ToString(),
+                                Name = album.Name,
+                                MediaType = album.MediaType,
+                                ParentId = album.ParentId.ToString(),
+                                IsTopParent = album.IsTopParent,
+                                DisplayParentId = album.DisplayParentId.ToString(),
+                            });
+                        }
+
+                        jj++;
+                    }
+                }
+
+                var options = new JsonSerializerOptions
+                {
+                    WriteIndented = true
+                };
+                using var writer = System.IO.File.Create(dumpFilePath);
+                using var textWriter = new StreamWriter(writer)
+                {
+                    AutoFlush = true
+                };
+                textWriter.WriteLine("[");
+                await JsonSerializer.SerializeAsync(writer, trackRefs, options, cancellationToken).ConfigureAwait(false);
+                textWriter.WriteLine(",");
+                await JsonSerializer.SerializeAsync(writer, artistRefs, options, cancellationToken).ConfigureAwait(false);
+                textWriter.WriteLine("]");
+                alreadyIncludedIds.Add(item.Id);
+            }
+
+            return NoContent();
+        }
+
+        private class ItemRef
+        {
+            public string Id { get; set; } = "notset";
+
+            public string Name { get; set; } = "notset";
+
+            public string MediaType { get; set; } = "notset";
+
+            public string ParentId { get; set; } = "notset";
+
+            public bool IsTopParent { get; set; }
+
+            public string DisplayParentId { get; set; } = "notset";
+        }
+
+        private class ArtistRef : ItemRef
+        {
+            public List<ItemRef> Children { get; set; } = new List<ItemRef>();
+
+            public List<ItemRef> RecursiveChildren { get; set; } = new List<ItemRef>();
+        }
+    }
+}

--- a/Viperinius.Plugin.SpotifyImport/Api/DebugController.cs
+++ b/Viperinius.Plugin.SpotifyImport/Api/DebugController.cs
@@ -104,7 +104,7 @@ namespace Viperinius.Plugin.SpotifyImport.Api
                 };
                 var trackRefs = new Dictionary<string, ItemRef>
                 {
-                    { $"{itemIndex}Track", trackRef },
+                    { $"Track[{itemIndex}]", trackRef },
                 };
 
                 // add album entity if set
@@ -119,7 +119,7 @@ namespace Viperinius.Plugin.SpotifyImport.Api
                         IsTopParent = audio.AlbumEntity.IsTopParent,
                         DisplayParentId = audio.AlbumEntity.DisplayParentId.ToString(),
                     };
-                    trackRefs.Add($"{itemIndex}TrackAlbumEntity", albumEntityRef);
+                    trackRefs.Add($"TrackAlbumEntity[{itemIndex}]", albumEntityRef);
                 }
 
                 // get track parents
@@ -138,7 +138,7 @@ namespace Viperinius.Plugin.SpotifyImport.Api
                         IsTopParent = nextParent.IsTopParent,
                         DisplayParentId = nextParent.DisplayParentId.ToString(),
                     };
-                    trackRefs.Add($"{itemIndex}Parent{ii}", nextRef);
+                    trackRefs.Add($"TrackParent{ii}[{itemIndex}]", nextRef);
                     ii++;
                 }
 
@@ -156,6 +156,7 @@ namespace Viperinius.Plugin.SpotifyImport.Api
                     artistResult = artistResult.Concat(_libraryManager.GetItemsResult(new InternalItemsQuery
                     {
                         SearchTerm = artistName[0..Math.Min(artistName.Length, 5)],
+                        MediaTypes = new[] { "MusicArtist" },
                     }).Items);
                     var resultCount2 = artistResult.Count() - resultCount1;
 
@@ -188,7 +189,7 @@ namespace Viperinius.Plugin.SpotifyImport.Api
                                 MediaType = c.MediaType,
                             }).ToList(),
                         };
-                        artistRefs.Add($"{itemIndex}/{artistIndex}Artist{jj}/{resultCount1}/{resultCount2}", artistRef);
+                        artistRefs.Add($"Artist{jj}[{itemIndex}][{artistIndex}]/{resultCount1}/{resultCount2}", artistRef);
 
                         // album by album artists
                         var albums = _libraryManager.GetItemList(new InternalItemsQuery
@@ -199,7 +200,7 @@ namespace Viperinius.Plugin.SpotifyImport.Api
                         for (int kk = 0; kk < albums.Count; kk++)
                         {
                             var album = albums[kk];
-                            trackRefs.Add($"{itemIndex}/{artistIndex}AlbumByAlbumArtist{kk}/{jj}/{artistName}", new ItemRef
+                            trackRefs.Add($"AlbumByAlbumArtist{jj}-{kk}[{itemIndex}][{artistIndex}]/{artistName}", new ItemRef
                             {
                                 Id = album.Id.ToString(),
                                 Name = album.Name,

--- a/Viperinius.Plugin.SpotifyImport/Configuration/PluginConfiguration.cs
+++ b/Viperinius.Plugin.SpotifyImport/Configuration/PluginConfiguration.cs
@@ -68,6 +68,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public ItemMatchLevel ItemMatchLevel { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to enable the legacy way of comparing tracks.
+    /// </summary>
+    public bool UseLegacyMatching { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether to enable the creation of files containing missing tracks on the server.
     /// </summary>
     public bool GenerateMissingTrackLists { get; set; }

--- a/Viperinius.Plugin.SpotifyImport/Configuration/configPage.html
+++ b/Viperinius.Plugin.SpotifyImport/Configuration/configPage.html
@@ -38,6 +38,24 @@
                             <span>Enable verbose logging for this plugin.</span>
                         </label>
                     </div>
+                    <div id="dbgSection" class="hide">
+                        <hr>
+                        <div class="sectionTitleContainer flex align-items-center">
+                            <h3 class="sectionTitle">Debugging</h3>
+                        </div>
+                        <div class="verticalSection">
+                            <button is="emby-button" type="button" id="dbgDumpMeta" class="raised block">
+                                <span>Dump Music Metadata To File</span>
+                            </button>
+                            <input id="dbgDumpRefsTrackName" type="text" is="emby-input" label="Track name to dump refs for" />
+                            <button is="emby-button" type="button" id="dbgDumpRefs" class="raised block">
+                                <span>Dump Music Track References To File</span>
+                            </button>
+                        </div>
+                        <hr>
+                        <br>
+                    </div>
+
                     <div class="inputContainer">
                         <input id="SpotifyClientId" type="text" is="emby-input" label="Spotify Client ID" />
                         <div class="fieldDescription">

--- a/Viperinius.Plugin.SpotifyImport/Configuration/configPage.html
+++ b/Viperinius.Plugin.SpotifyImport/Configuration/configPage.html
@@ -190,6 +190,15 @@
                                 <span>Enable artist comparison.</span>
                             </label>
                         </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="UseLegacyMatching" name="UseLegacyMatching" type="checkbox" is="emby-checkbox" />
+                                <span>Use legacy track matching (not recommended).</span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">
+                                If this is enabled the plugin tries to find Jellyfin tracks by searching for the track name instead of hierarchically starting from the artist.
+                            </div>
+                        </div>
                     </div>
 
                     <div>

--- a/Viperinius.Plugin.SpotifyImport/Configuration/playlistConfig.js
+++ b/Viperinius.Plugin.SpotifyImport/Configuration/playlistConfig.js
@@ -199,6 +199,10 @@ export default function (view) {
         apiQueryOpts.api_key = ApiClient.accessToken();
 
         ApiClient.getPluginConfiguration(SpotifyImportConfig.pluginUniqueId).then(function (config) {
+            if (config.EnableVerboseLogging) {
+                document.querySelector('#dbgSection').classList.remove('hide');
+            }
+
             document.querySelector('#SpotifyAuthRedirectUri').innerText = ApiClient.getUrl(SpotifyImportConfig.pluginApiBaseUrl + '/SpotifyAuthCallback');
             if (config.SpotifyAuthToken && 'CreatedAt' in config.SpotifyAuthToken) {
                 document.querySelector('#authSpotifyAlreadyDesc').classList.remove('hide');
@@ -339,6 +343,43 @@ export default function (view) {
 
                 window.open(json['login_req_uri'], '_self');
             });
+        }).catch(function (error) {
+            console.error(error);
+        });
+    });
+
+    const dbgDumpMetaBtn = document.querySelector('#dbgDumpMeta');
+    dbgDumpMetaBtn.addEventListener('click', function () {
+        const apiUrl = ApiClient.getUrl(SpotifyImportConfig.pluginApiBaseUrl + '/Debug/DumpMetadata', {
+            'api_key': apiQueryOpts.api_key
+        });
+
+        dbgDumpMetaBtn.disabled = true;
+
+        fetch(apiUrl, { method: 'POST' }).then(function (res) {
+            dbgDumpMetaBtn.disabled = false;
+            if (!res || !res.ok) {
+                throw "invalid response";
+            }
+        }).catch(function (error) {
+            console.error(error);
+        });
+    });
+    const dbgDumpRefsBtn = document.querySelector('#dbgDumpRefs');
+    dbgDumpRefsBtn.addEventListener('click', function () {
+        const name = document.querySelector('#dbgDumpRefsTrackName').value;
+        const apiUrl = ApiClient.getUrl(SpotifyImportConfig.pluginApiBaseUrl + '/Debug/DumpTrackRefs', {
+            name: name,
+            'api_key': apiQueryOpts.api_key
+        });
+
+        dbgDumpRefsBtn.disabled = true;
+
+        fetch(apiUrl, { method: 'POST' }).then(function (res) {
+            dbgDumpRefsBtn.disabled = false;
+            if (!res || !res.ok) {
+                throw "invalid response";
+            }
         }).catch(function (error) {
             console.error(error);
         });

--- a/Viperinius.Plugin.SpotifyImport/Configuration/playlistConfig.js
+++ b/Viperinius.Plugin.SpotifyImport/Configuration/playlistConfig.js
@@ -255,6 +255,7 @@ export default function (view) {
 
             document.querySelector('#ItemMatchLevel').value = config.ItemMatchLevel;
             mapItemMatchCriteriaToCheckboxes(config);
+            document.querySelector('#UseLegacyMatching').checked = config.UseLegacyMatching;
 
             ApiClient.getJSON(ApiClient.getUrl('Users'), apiQueryOpts).then(function (result) {
                 users.length = 0;
@@ -315,6 +316,7 @@ export default function (view) {
                 Dashboard.hideLoadingMsg();
                 return;
             }
+            config.UseLegacyMatching = document.querySelector('#UseLegacyMatching').checked;
 
             ApiClient.updatePluginConfiguration(SpotifyImportConfig.pluginUniqueId, config).then(function (result) {
                 Dashboard.processPluginConfigurationUpdateResult(result);
@@ -361,6 +363,7 @@ export default function (view) {
             if (!res || !res.ok) {
                 throw "invalid response";
             }
+            console.log('dump done');
         }).catch(function (error) {
             console.error(error);
         });
@@ -380,6 +383,7 @@ export default function (view) {
             if (!res || !res.ok) {
                 throw "invalid response";
             }
+            console.log('dump done');
         }).catch(function (error) {
             console.error(error);
         });

--- a/Viperinius.Plugin.SpotifyImport/Matchers/TrackComparison.cs
+++ b/Viperinius.Plugin.SpotifyImport/Matchers/TrackComparison.cs
@@ -99,7 +99,8 @@ namespace Viperinius.Plugin.SpotifyImport.Matchers
 
         public static bool AlbumNameEqual(Audio jfItem, ProviderTrackInfo providerItem, ItemMatchLevel matchLevel)
         {
-            return Equal(jfItem.AlbumEntity?.Name, providerItem.AlbumName, matchLevel);
+            return Equal(jfItem.AlbumEntity?.Name, providerItem.AlbumName, matchLevel) ||
+                   Equal(jfItem.Album, providerItem.AlbumName, matchLevel);
         }
 
         public static bool AlbumNameEqual(MusicAlbum jfItem, ProviderTrackInfo providerItem, ItemMatchLevel matchLevel)
@@ -109,7 +110,8 @@ namespace Viperinius.Plugin.SpotifyImport.Matchers
 
         public static bool AlbumArtistOneContained(Audio jfItem, ProviderTrackInfo providerItem, ItemMatchLevel matchLevel)
         {
-            return ListMatchOneItem(jfItem.AlbumEntity?.Artists, providerItem.AlbumArtistNames, matchLevel);
+            return ListMatchOneItem(jfItem.AlbumEntity?.Artists, providerItem.AlbumArtistNames, matchLevel) ||
+                   ListMatchOneItem(jfItem.AlbumArtists, providerItem.AlbumArtistNames, matchLevel);
         }
 
         public static bool AlbumArtistOneContained(MusicAlbum jfItem, ProviderTrackInfo providerItem, ItemMatchLevel matchLevel)

--- a/Viperinius.Plugin.SpotifyImport/PlaylistSync.cs
+++ b/Viperinius.Plugin.SpotifyImport/PlaylistSync.cs
@@ -194,7 +194,7 @@ namespace Viperinius.Plugin.SpotifyImport
 
                 if (Plugin.Instance?.Configuration.EnableVerboseLogging ?? false)
                 {
-                    _logger.LogDebug("> Found matching artist {Name}", artist.Name);
+                    _logger.LogDebug("> Found matching artist {Name} {Id}", artist.Name, artist.Id);
                 }
 
                 var albumNextIndex = 0;
@@ -209,7 +209,7 @@ namespace Viperinius.Plugin.SpotifyImport
 
                     if (Plugin.Instance?.Configuration.EnableVerboseLogging ?? false)
                     {
-                        _logger.LogDebug("> Found matching album {Name}", album.Name);
+                        _logger.LogDebug("> Found matching album {Name} {Id}", album.Name, album.Id);
                     }
 
                     if (!CheckAlbumArtist(album, providerTrackInfo))
@@ -232,7 +232,7 @@ namespace Viperinius.Plugin.SpotifyImport
 
                     if (Plugin.Instance?.Configuration.EnableVerboseLogging ?? false)
                     {
-                        _logger.LogDebug("> Found matching track {Name}", track.Name);
+                        _logger.LogDebug("> Found matching track {Name} {Id}", track.Name, track.Id);
                     }
 
                     failedMatchCriterium = ItemMatchCriteria.None;
@@ -305,7 +305,7 @@ namespace Viperinius.Plugin.SpotifyImport
         private MusicAlbum? GetAlbum(MusicArtist artist, ProviderTrackInfo providerTrackInfo, ref int nextAlbumIndex)
         {
             var albums = artist.Children;
-            if (!artist.Children.Any())
+            if (!albums.Any())
             {
                 // for whatever reason albums are apparently not always set as children of the artist... so try to find them using album artist
                 albums = _libraryManager.GetItemList(new MediaBrowser.Controller.Entities.InternalItemsQuery
@@ -321,7 +321,7 @@ namespace Viperinius.Plugin.SpotifyImport
             {
                 if (Plugin.Instance?.Configuration.EnableVerboseLogging ?? false)
                 {
-                    _logger.LogInformation("> Reached end of album list");
+                    _logger.LogInformation("> Reached end of album list (has {Count} entries)", albums.Count());
                 }
 
                 nextAlbumIndex = -1;

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "Spotify Import"
 guid: "F03D0ADB-289F-4986-BD6F-2468025249B3"
 imageUrl: "https://github.com/Viperinius/jellyfin-plugin-spotify-import/raw/master/viperinius-plugin-spotifyimport.png"
-version: "1.7.0.2"
+version: "1.7.0.3"
 targetAbi: "10.8.0.0"
 framework: "net6.0"
 overview: "This plugin imports playlists from Spotify."
@@ -16,6 +16,10 @@ artifacts:
 - "SpotifyAPI.Web.dll"
 changelog: |2-
   # Changelog
+
+  ## [1.7.0.3] - 2024-03-17
+
+  (Internal testing release)
 
   ## [1.7.0.2] - 2024-03-17
 

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "Spotify Import"
 guid: "F03D0ADB-289F-4986-BD6F-2468025249B3"
 imageUrl: "https://github.com/Viperinius/jellyfin-plugin-spotify-import/raw/master/viperinius-plugin-spotifyimport.png"
-version: "1.7.0.0"
+version: "1.7.0.1"
 targetAbi: "10.8.0.0"
 framework: "net6.0"
 overview: "This plugin imports playlists from Spotify."
@@ -16,6 +16,10 @@ artifacts:
 - "SpotifyAPI.Web.dll"
 changelog: |2-
   # Changelog
+
+  ## [1.7.0.1] - 2024-03-17
+
+  (Internal testing release)
 
   ## [1.7.0.0] - 2024-03-10
 

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "Spotify Import"
 guid: "F03D0ADB-289F-4986-BD6F-2468025249B3"
 imageUrl: "https://github.com/Viperinius/jellyfin-plugin-spotify-import/raw/master/viperinius-plugin-spotifyimport.png"
-version: "1.7.0.1"
+version: "1.7.0.2"
 targetAbi: "10.8.0.0"
 framework: "net6.0"
 overview: "This plugin imports playlists from Spotify."
@@ -16,6 +16,10 @@ artifacts:
 - "SpotifyAPI.Web.dll"
 changelog: |2-
   # Changelog
+
+  ## [1.7.0.2] - 2024-03-17
+
+  (Internal testing release)
 
   ## [1.7.0.1] - 2024-03-17
 


### PR DESCRIPTION
Add track matching using the previous method as a configurable alternative to keep support for flat libraries, see #24 