### PR TITLE
feature/enhancement?: allow bringing your own oauth access token as an authentication method

### DIFF
--- a/Viperinius.Plugin.SpotifyImport/Configuration/configPage.html
+++ b/Viperinius.Plugin.SpotifyImport/Configuration/configPage.html
@@ -66,24 +66,29 @@
                         </div>
                     </div>
 
+                    <div class="sectionTitleContainer flex align-items-center">
+                        <h5 class="sectionTitle">Spotify Auth Token JSON </h5>
+                    </div>
                     <div class="inputContainer">
-                        <textarea id="SpotifyOAuthTokenJson" is="emby-textarea" label="Spotify Auth Token (JSON)"></textarea>
+                        <textarea id="SpotifyOAuthTokenJson" is="emby-textarea" label="Spotify Auth Token JSON" style="min-width: 100%; min-height: 10em; max-width: 50vw; field-sizing: content"></textarea>
                         <div class="fieldDescription">
-                            Enter the JSON representation of a PKCETokenResponse object from SpotifyAPI.Web.
-                            The CreatedAt field is optional and will be automatically set to a past date if omitted.
-                            <br><br>
+                            Enter the JSON representation of a Spotify OAuth Access Token. <br>
+                            The CreatedAt field is optional and will be automatically set to a past date if omitted. <br>
+                            Ensure you also have supplied the client id that was used to create this token. Spotify default client id + tokens are accepted. <br>
+                            Refresh functionality is currently unavailable. Generate a token and you should have access for an hour. <br>
+                            <br>
+                            <strong>WARNING DANGEROUS: If valid, this field will automatically replace any stored token.</strong>
+                            <br>
                             <strong>Required fields:</strong> AccessToken, TokenType, ExpiresIn, RefreshToken, Scope<br>
                             <strong>Optional fields:</strong> CreatedAt
                             <br><br>
                             <strong>Example:</strong>
-                            <pre style="background-color: #f5f5f5; padding: 10px; border-radius: 4px; overflow-x: auto; font-size: 12px; margin: 10px 0;">
-{
-  "AccessToken": "BQC4liRpfwMiW-NmU9h3cszJqHksTXzY8UZG0b7wLrABCDEF1234567890abcdef",
-  "TokenType": "Bearer",
-  "ExpiresIn": 3600,
-  "RefreshToken": "AQD-ExampleRefreshToken1234567890abcdefghijklmnopqrstuvwxyz",
-  "Scope": "playlist-read-private playlist-read-collaborative"
-}</pre>
+                            <pre style="background-color: #f5f5f5; padding: 10px; border-radius: 4px; overflow-x: auto; font-size: 12px; margin: 10px 0; color: black">
+{"AccessToken": "BeArEr-ExAMPle_ACCESSTOKEN-abcde",
+"TokenType": "Bearer",
+"ExpiresIn": 3600,
+"RefreshToken": "AQD-ExampleRefreshToken12345",
+"Scope": "playlist-read playlist-read-private playlist-read-collaborative"}</pre>
                             <small><em>Note: Replace the example values with your actual Spotify token data.</em></small>
                         </div>
                     </div>

--- a/Viperinius.Plugin.SpotifyImport/Configuration/configPage.html
+++ b/Viperinius.Plugin.SpotifyImport/Configuration/configPage.html
@@ -8,15 +8,17 @@
 
 <body>
     <div id="SpotifyImportConfigPage" data-role="page" class="page type-interior pluginConfigurationPage"
-        data-require="emby-input,emby-button,emby-select,emby-checkbox,emby-textarea"
-        data-controller="__plugin/playlistconfigjs">
+         data-require="emby-input,emby-button,emby-select,emby-checkbox,emby-textarea"
+         data-controller="__plugin/playlistconfigjs">
         <style>
             .playlistContainer, .usersContainer, .multiCheckboxContainer {
                 margin-bottom: 1.8em;
             }
-            .multiCheckboxContainer .emby-checkbox-label {
-                margin-bottom: 0.25em;
-            }
+
+                .multiCheckboxContainer .emby-checkbox-label {
+                    margin-bottom: 0.25em;
+                }
+
             .multiCheckboxContainerTitle {
                 margin-bottom: 0.25em;
             }
@@ -63,6 +65,29 @@
                             Make sure to use "<span id="SpotifyAuthRedirectUri"></span>" as Redirect URI.
                         </div>
                     </div>
+
+                    <div class="inputContainer">
+                        <textarea id="SpotifyOAuthTokenJson" is="emby-textarea" label="Spotify Auth Token (JSON)"></textarea>
+                        <div class="fieldDescription">
+                            Enter the JSON representation of a PKCETokenResponse object from SpotifyAPI.Web.
+                            The CreatedAt field is optional and will be automatically set to a past date if omitted.
+                            <br><br>
+                            <strong>Required fields:</strong> AccessToken, TokenType, ExpiresIn, RefreshToken, Scope<br>
+                            <strong>Optional fields:</strong> CreatedAt
+                            <br><br>
+                            <strong>Example:</strong>
+                            <pre style="background-color: #f5f5f5; padding: 10px; border-radius: 4px; overflow-x: auto; font-size: 12px; margin: 10px 0;">
+{
+  "AccessToken": "BQC4liRpfwMiW-NmU9h3cszJqHksTXzY8UZG0b7wLrABCDEF1234567890abcdef",
+  "TokenType": "Bearer",
+  "ExpiresIn": 3600,
+  "RefreshToken": "AQD-ExampleRefreshToken1234567890abcdefghijklmnopqrstuvwxyz",
+  "Scope": "playlist-read-private playlist-read-collaborative"
+}</pre>
+                            <small><em>Note: Replace the example values with your actual Spotify token data.</em></small>
+                        </div>
+                    </div>
+
                     <div class="verticalSection">
                         <div class="fieldDescription hide" id="authSpotifyAlreadyDesc">
                             Found an existing authorization. (Created at: <span id="authSpotifyCreatedAt"></span>)
@@ -96,12 +121,12 @@
                         <div class="innerPlaylistContainer">
                             <table id="playlistTable" class="stripedTable ui-responsive table-stroke detailTable" data-role="table">
                                 <thead>
-                                    <th class="detailTableHeaderCell" data-priority="persist">Spotify ID</th>
-                                    <th class="detailTableHeaderCell" data-priority="persist">Target Name</th>
-                                    <th class="detailTableHeaderCell" data-priority="persist">Target User</th>
-                                    <th class="detailTableHeaderCell" data-priority="persist">Set To Private</th>
-                                    <th class="detailTableHeaderCell" data-priority="persist">Always From Scratch</th>
-                                    <th></th>
+                                <th class="detailTableHeaderCell" data-priority="persist">Spotify ID</th>
+                                <th class="detailTableHeaderCell" data-priority="persist">Target Name</th>
+                                <th class="detailTableHeaderCell" data-priority="persist">Target User</th>
+                                <th class="detailTableHeaderCell" data-priority="persist">Set To Private</th>
+                                <th class="detailTableHeaderCell" data-priority="persist">Always From Scratch</th>
+                                <th></th>
                                 </thead>
                                 <tbody>
                                 </tbody>
@@ -129,11 +154,11 @@
                         <div class="innerUsersContainer">
                             <table id="userlistTable" class="stripedTable ui-responsive table-stroke detailTable" data-role="table">
                                 <thead>
-                                    <th class="detailTableHeaderCell" data-priority="persist">Spotify ID</th>
-                                    <th class="detailTableHeaderCell" data-priority="persist">Target User</th>
-                                    <th class="detailTableHeaderCell" data-priority="persist">Set To Private</th>
-                                    <th class="detailTableHeaderCell" data-priority="persist">Only Original Playlists</th>
-                                    <th></th>
+                                <th class="detailTableHeaderCell" data-priority="persist">Spotify ID</th>
+                                <th class="detailTableHeaderCell" data-priority="persist">Target User</th>
+                                <th class="detailTableHeaderCell" data-priority="persist">Set To Private</th>
+                                <th class="detailTableHeaderCell" data-priority="persist">Only Original Playlists</th>
+                                <th></th>
                                 </thead>
                                 <tbody>
                                 </tbody>

--- a/Viperinius.Plugin.SpotifyImport/Configuration/playlistConfig.js
+++ b/Viperinius.Plugin.SpotifyImport/Configuration/playlistConfig.js
@@ -156,7 +156,7 @@ function getPlaylistTableData(page) {
                 Name: renameTo,
                 UserName: jellyfinUser,
                 IsPrivate: isPrivate,
-                RecreateFromScratch : recreateFromScratch,
+                RecreateFromScratch: recreateFromScratch,
             };
         });
 
@@ -244,6 +244,27 @@ export default function (view) {
             document.querySelector('#ShowCompletenessInformation').checked = config.ShowCompletenessInformation;
             document.querySelector('#SpotifyClientId').value = config.SpotifyClientId;
             document.querySelector('#SpotifyCookie').value = config.SpotifyCookie;
+            document.querySelector('#SpotifyOAuthTokenJson').value = config.SpotifyOAuthTokenJson || '';
+
+            // Parse the SpotifyOAuthTokenJson and update SpotifyAuthToken if valid JSON is provided
+            if (config.SpotifyOAuthTokenJson && config.SpotifyOAuthTokenJson.trim() !== '') {
+                try {
+                    const parsedToken = JSON.parse(config.SpotifyOAuthTokenJson);
+                    // Validate that required fields are present (CreatedAt is optional)
+                    if (parsedToken.AccessToken && parsedToken.TokenType && parsedToken.ExpiresIn &&
+                        parsedToken.RefreshToken && parsedToken.Scope) {
+                        config.SpotifyAuthToken = parsedToken;
+                    } else {
+                        Dashboard.alert('Invalid JSON structure for SpotifyOAuthToken. Required fields: AccessToken, TokenType, ExpiresIn, RefreshToken, Scope. Optional fields: CreatedAt');
+                        Dashboard.hideLoadingMsg();
+                        return;
+                    }
+                } catch (jsonError) {
+                    Dashboard.alert('Invalid JSON format for SpotifyOAuthToken: ' + jsonError.message);
+                    Dashboard.hideLoadingMsg();
+                    return;
+                }
+            }
 
             document.querySelector('#GenerateMissingTrackLists').checked = config.GenerateMissingTrackLists;
             document.querySelector('#MissingTrackListsDateFormat').value = config.MissingTrackListsDateFormat;
@@ -318,6 +339,27 @@ export default function (view) {
             config.ShowCompletenessInformation = document.querySelector('#ShowCompletenessInformation').checked;
             config.SpotifyClientId = document.querySelector('#SpotifyClientId').value;
             config.SpotifyCookie = document.querySelector('#SpotifyCookie').value;
+            config.SpotifyOAuthTokenJson = document.querySelector('#SpotifyOAuthTokenJson').value;
+
+            // Parse the SpotifyOAuthTokenJson and update SpotifyAuthToken if valid JSON is provided
+            if (config.SpotifyOAuthTokenJson && config.SpotifyOAuthTokenJson.trim() !== '') {
+                try {
+                    const parsedToken = JSON.parse(config.SpotifyOAuthTokenJson);
+                    // Validate that required fields are present (CreatedAt is optional)
+                    if (parsedToken.AccessToken && parsedToken.TokenType && parsedToken.ExpiresIn &&
+                        parsedToken.RefreshToken && parsedToken.Scope) {
+                        config.SpotifyAuthToken = parsedToken;
+                    } else {
+                        Dashboard.alert('Invalid JSON structure for SpotifyOAuthToken. Required fields: AccessToken, TokenType, ExpiresIn, RefreshToken, Scope. Optional fields: CreatedAt');
+                        Dashboard.hideLoadingMsg();
+                        return;
+                    }
+                } catch (jsonError) {
+                    Dashboard.alert('Invalid JSON format for SpotifyOAuthToken: ' + jsonError.message);
+                    Dashboard.hideLoadingMsg();
+                    return;
+                }
+            }
 
             config.Playlists = [];
             const playlists = getPlaylistTableData(view) || [];


### PR DESCRIPTION
### Feature/enhancement? Update the settings page with a new field input to support bringing your own OAuth token

The provided JSON token is parsed to create the global Token object.

_To use:_ 
client id: [i.e. the default web player id]
json oauth token: [i.e one generated by librespot's OAuth builder] in the format of...
```
{
    "AccessToken": "BeArEr-ExAMPle_ACCESSTOKEN-abcde",
    "TokenType": "Bearer",
    "ExpiresIn": 3600,
    "RefreshToken": "AQD-ExampleRefreshToken12345",
    "Scope": "playlist-read playlist-read-private playlist-read-collaborative"
}
```

**Limitation/bug**: The token refresh function is broken. I haven't looked into what exactly is going wrong, and I can't test whether or not the same thing happens with a regular Web API authorization.

**Future**: may want to look into integrating/using a third-party library like librespot for metadata retrieval/authentication flows 

<img width="835" height="789" alt="image" src="https://github.com/user-attachments/assets/42d81fad-b1bc-4c6e-b115-22fa08f8e76e" />

